### PR TITLE
Add compatibility for Essentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,6 @@
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
@@ -106,12 +100,6 @@
             <artifactId>HikariCP</artifactId>
             <version>3.4.5</version>
             <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.tnemc</groupId>
-            <artifactId>Reserve</artifactId>
-            <version>0.1.1.0</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/me/xanium/gemseconomy/GemsEconomy.java
+++ b/src/main/java/me/xanium/gemseconomy/GemsEconomy.java
@@ -103,10 +103,10 @@ public class GemsEconomy extends JavaPlugin {
         initializeDataStore(getConfig().getString("storage"), true);
 
         getServer().getPluginManager().registerEvents(new EconomyListener(), this);
-        getCommand("balance").setExecutor(new BalanceCommand());
-        getCommand("baltop").setExecutor(new BalanceTopCommand());
-        getCommand("economy").setExecutor(new EconomyCommand());
-        getCommand("pay").setExecutor(new PayCommand());
+        getCommand("gbalance").setExecutor(new BalanceCommand());
+        getCommand("gbaltop").setExecutor(new BalanceTopCommand());
+        getCommand("geconomy").setExecutor(new EconomyCommand());
+        getCommand("gpay").setExecutor(new PayCommand());
         getCommand("currency").setExecutor(new CurrencyCommand());
         getCommand("cheque").setExecutor(new ChequeCommand());
         getCommand("exchange").setExecutor(new ExchangeCommand());

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,26 +10,26 @@ loadbefore:
   - ItemFrameShops
 softdepend: [Vault]
 commands:
-  balance:
+  gbalance:
     description: Shows your balances
-    usage: /balance (account)
-    aliases: [gbal, gmoney, bal]
-  baltop:
+    usage: /gbalance (account)
+    aliases: [gbal, gmoney, balance, bal]
+  gbaltop:
     description: Shows the top balances of the server
-    usage: /baltop (currency) (page)
-    aliases: [gmoneytop, gecotop, gtop, gbaltop]
+    usage: /gbaltop (currency) (page)
+    aliases: [gmoneytop, gecotop, gtop, gbaltop, baltop]
   currency:
     description: Manage the currencies.
     usage: /currency
     aliases: [gcurr, gemscurrencies, gcurrency, currencies]
-  economy:
+  geconomy:
     description: Give, set or take currency.
-    usage: /eco <set|take|give> <account> <amount> (currency)
-    aliases: [geconomy, eco, geco, gemseconomy]
-  pay:
+    usage: /geco <set|take|give> <account> <amount> (currency)
+    aliases: [economy, eco, geco, gemseconomy]
+  gpay:
     description: Pays another account
-    usage: /pay <account> <amount> (currency)
-    aliases: [gpay, gemspay]
+    usage: /gpay <account> <amount> (currency)
+    aliases: [pay, gemspay]
   cheque:
     usage: /cheque
     description: Write or Redeem a cheque.


### PR DESCRIPTION
I have recently installed GemsEconomy on my server and I shortly realized that most economy related commands of Essentials were overrided by Gems. I personally use Gems for creating extra economies, not to replace Essentials.
Commands like `balance` were replaced by `gbalance` and moved as alias.